### PR TITLE
Fixed Typo between fF in table and in code

### DIFF
--- a/analysis/likelihood_ratio_simple_models.Rmd
+++ b/analysis/likelihood_ratio_simple_models.Rmd
@@ -46,7 +46,7 @@ marker | $f_S$ | $f_F$ |
 2 | 0.12 | 0.20 |
 3 | 0.21 | 0.11 |
 4 | 0.12 | 0.17 |
-5 | 0.02 | 0.03 |
+5 | 0.02 | 0.23 |
 6 | 0.32 | 0.25 |
 
 The question before us is: Which subspecies of elephant did the tusk come from, and how confident should we be in this conclusion?


### PR DESCRIPTION
Noticed that the table of allele frequencies is not consistent with the R code in the elephant example. Assumed the R code has the correct allele frequencies (swapped 0.03 for 0.23 in Forest elephants in table). If it is the opposite (table is more correct than R code) than should be able to swap easily. Just wanted to make sure the discrepancy is resolved since this is an awesome resource! 
