### PR TITLE
Adding more Discrete Markov Chain material

### DIFF
--- a/analysis/index.Rmd
+++ b/analysis/index.Rmd
@@ -30,6 +30,12 @@ title: "Home"
 
 ### Stochastic Processes
 
+*  [Discrete Markov Chains: Introduction](markov_chains_discrete_introduction.html)
+
+*  [Discrete Markov Chains: Finding the Stationary Distribution via solution of the global balance equations](stationary_distribution.html)
+
+*  [Discrete Markov Chains: Finding the Stationary Distribution via eigendecomposition](markov_chains_discrete_stationary_dist.html)
+
 *  [Simulating Discrete Markov Chains: An Introduction](simulating_discrete_chains_1.html)
+
 *  [Simulating Discrete Markov Chains: Limiting Distributions](simulating_discrete_chains_2.html)
-*  [Discrete Markov Chains: Finding the Stationary Distribution](stationary_distribution.html)

--- a/analysis/index.html
+++ b/analysis/index.html
@@ -130,8 +130,8 @@ img {
 </ul>
 </div>
 
-<p><strong>Last updated:</strong> 2016-01-30</p>
-<p><strong>Code version:</strong> 4e0c4fd08bc82ec646c5ce145c78fa019af5314d</p>
+<p><strong>Last updated:</strong> 2016-01-31</p>
+<p><strong>Code version:</strong> c8c677bb060d7b9183bbe7a9080b9bbf72d23df8</p>
 <div id="inference" class="section level2">
 <h2>Inference</h2>
 <div id="likelihood-ratio-and-likelihood" class="section level3">
@@ -155,9 +155,11 @@ img {
 <div id="stochastic-processes" class="section level3">
 <h3>Stochastic Processes</h3>
 <ul>
-<li><a href="simulating_discrete_chains_1.html">Simulating Discrete Markov Chains: An Introduction</a></li>
-<li><a href="simulating_discrete_chains_2.html">Simulating Discrete Markov Chains: Limiting Distributions</a></li>
-<li><a href="stationary_distribution.html">Discrete Markov Chains: Finding the Stationary Distribution</a></li>
+<li><p><a href="markov_chains_discrete_introduction.html">Discrete Markov Chains: Introduction</a></p></li>
+<li><p><a href="markov_chains_discrete_stationary_dist.html">Discrete Markov Chains: Finding the Stationary Distribution via eigendecomposition</a></p></li>
+<li><p><a href="stationary_distribution.html">Discrete Markov Chains: Finding the Stationary Distribution via solution of the global balance equations</a></p></li>
+<li><p><a href="simulating_discrete_chains_1.html">Simulating Discrete Markov Chains: An Introduction</a></p></li>
+<li><p><a href="simulating_discrete_chains_2.html">Simulating Discrete Markov Chains: Limiting Distributions</a></p></li>
 </ul>
 </div>
 </div>

--- a/analysis/markov_chains_discrete_intro.Rmd
+++ b/analysis/markov_chains_discrete_intro.Rmd
@@ -1,0 +1,85 @@
+---
+title: "Introduction to Discrete Markov Chains"
+author: "John Novembre"
+date: 2016-01-31
+---
+
+**Last updated:** `r Sys.Date()`
+
+**Code version:** `r system("git log -1 --format='%H'", intern = TRUE)`
+
+```{r chunk-options, include=FALSE}
+source("chunk-options.R")
+```
+
+# Pre-requisites
+
+An understanding of matrix multiplication and matrix powers.  
+
+# Overview
+
+Here we provide a quick introduction to discrete Markov Chains.
+
+# Definition of a Markov Chain
+
+A Markov Chain is a discrete stochastic process with the *Markov property* : $P(X_t|X_{t-1},\ldots,X_1)= P(X_t|X_{t-1})$.  It is fully determined by a probability transition matrix $P$ which defines the transition probabilities ($P_ij=P(X_t=j|X_{t-1}=i)$ and an initial probability distribution specficied by the vector $x$ where $x_i=P(X_0=i)$.  The time-dependent random variable $X_t$ is describing the state of our probabilistic system at time-step $t$.  
+
+# Example: Gary's mood
+
+In Sheldon Ross's Introduction to Probability Models, he has an example (4.3) of a Markov Chain for modeling Gary's mood.  Gary alternates between 3 state: Cheery ($X=1$), So-So ($X=2$), or Glum ($X=3$).  Here we input the $P$ matrix given by Ross and we input an abitrary initial probability matrix. 
+
+```{r}
+# Define prob transition matrix 
+# (note matrix() takes vectors in column form so there is a transpose here to switch col's to row's)
+P=t(matrix(c(c(0.5,0.4,0.1),c(0.3,0.4,0.3),c(0.2,0.3,0.5)),nrow=3))
+# Check sum across = 1
+apply(P,1,sum)  
+
+# Definte initial probability vector
+x0=c(0.1,0.2,0.7)
+# Check sums to 1
+sum(x0)
+```
+
+# What are the expected probability states after one or two steps?
+
+If initial prob distribution $x_0$ is $3 \times 1$ column vector, then $x_0^T P= x_1^T$. In R, the %*% operator automatically promotes a vector to the appropriate matrix to make the arguments conformable.  In the case of multiplying a length 3 vector by a $3\time 3$ matrix, it takes the vector to be a row-vector. This means our math can look simply:
+```{r}
+# After one step
+x0%*%P
+```
+And after two time-steps:
+```{r}
+## The two-step prob trans matrix
+P%*%P
+## Multiplied by the initial state probability
+x0%*%P%*%P
+```
+
+# What about an abitrary number of time steps? 
+To generalize to an abitrary number of time steps into the future, we can compute a the matrix power.  In R, this can be done easily with the package expm.  Let's load the library and verify the second power is the same as we saw for P%*%P above. 
+```{r}
+# Load library 
+library(expm)
+# Verify the second power is P%*%P
+P%^%2
+```
+
+And now let's push this : Looking at the state of the chain after many steps, say 100.  First let's look at the probability transition matrix...
+```{r}
+P%^%100
+```
+What do you notice about the rows?   And let's see what this does for various starting distrbutions:
+```{r}
+c(1,0,0) %*%(P%^%100)
+c(0.2,0.5,0.3) %*%(P%^%100)
+```
+Note that after a large number of steps the initial state does not matter any more, the probability of the chain being in any state $j$ is independent of where we started.  This is our first view of the *equilibrium distribuion* of a Markov Chain.  These are also known as the *limiting probabilities of a Markov chain* or *stationary distribution*.  
+
+
+
+## Session information
+
+```{r info}
+sessionInfo()
+```

--- a/analysis/markov_chains_discrete_intro.html
+++ b/analysis/markov_chains_discrete_intro.html
@@ -1,0 +1,291 @@
+<!DOCTYPE html>
+
+<html xmlns="http://www.w3.org/1999/xhtml">
+
+<head>
+
+<meta charset="utf-8">
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+<meta name="generator" content="pandoc" />
+
+<meta name="author" content="John Novembre" />
+
+<meta name="date" content="2016-01-31" />
+
+<title>Introduction to Discrete Markov Chains</title>
+
+<script src="libs/jquery-1.11.0/jquery.min.js"></script>
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<link href="libs/bootstrap-3.3.1/css/united.min.css" rel="stylesheet" />
+<script src="libs/bootstrap-3.3.1/js/bootstrap.min.js"></script>
+<script src="libs/bootstrap-3.3.1/shim/html5shiv.min.js"></script>
+<script src="libs/bootstrap-3.3.1/shim/respond.min.js"></script>
+
+<style type="text/css">
+
+/* padding for bootstrap navbar */
+body {
+  padding-top: 50px;
+  padding-bottom: 40px;
+}
+
+
+/* offset scroll position for anchor links (for fixed navbar)  */
+.section h2 {
+  padding-top: 55px;
+  margin-top: -55px;
+}
+.section h3 {
+  padding-top: 55px;
+  margin-top: -55px;
+}
+
+
+
+/* don't use link color in navbar */
+.dropdown-menu>li>a {
+  color: black;
+}
+
+/* some padding for disqus */
+#disqus_thread {
+  margin-top: 45px;
+}
+
+</style>
+
+<link rel="stylesheet" href="libs/font-awesome-4.1.0/css/font-awesome.min.css"/>
+
+<style type="text/css">code{white-space: pre;}</style>
+<link rel="stylesheet"
+      href="libs/highlight/textmate.css"
+      type="text/css" />
+<script src="libs/highlight/highlight.js"></script>
+<style type="text/css">
+  pre:not([class]) {
+    background-color: white;
+  }
+</style>
+<script type="text/javascript">
+if (window.hljs && document.readyState && document.readyState === "complete") {
+   window.setTimeout(function() {
+      hljs.initHighlighting();
+   }, 0);
+}
+</script>
+
+
+
+</head>
+
+<body>
+
+<style type = "text/css">
+.main-container {
+  max-width: 940px;
+  margin-left: auto;
+  margin-right: auto;
+}
+code {
+  color: inherit;
+  background-color: rgba(0, 0, 0, 0.04);
+}
+img { 
+  max-width:100%; 
+  height: auto; 
+}
+</style>
+<div class="container-fluid main-container">
+
+
+<div class="navbar navbar-default navbar-fixed-top" role="navigation">
+  <div class="container">
+    <div class="navbar-header">
+      <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#navbar">
+        <span class="icon-bar"></span>
+        <span class="icon-bar"></span>
+        <span class="icon-bar"></span>
+      </button>
+      <a class="navbar-brand" href="index.html">fiveMinuteStats</a>
+    </div>
+    <div id="navbar" class="navbar-collapse collapse">
+      <ul class="nav navbar-nav">
+        <li><a href="index.html">Home</a></li>
+        <li><a href="about.html">About</a></li>
+        <li><a href="license.html">License</a></li>
+        <li><a href="https://github.com/stephens999/fiveMinuteStats">GitHub</a></li>
+    </div><!--/.nav-collapse -->
+  </div><!--/.container -->
+</div><!--/.navbar -->
+
+<div id="header">
+<h1 class="title">Introduction to Discrete Markov Chains</h1>
+<h4 class="author"><em>John Novembre</em></h4>
+<h4 class="date"><em>2016-01-31</em></h4>
+</div>
+
+<div id="TOC">
+<ul>
+<li><a href="#pre-requisites">Pre-requisites</a></li>
+<li><a href="#overview">Overview</a></li>
+<li><a href="#definition-of-a-markov-chain">Definition of a Markov Chain</a></li>
+<li><a href="#example-garys-mood">Example: Gary’s mood</a></li>
+<li><a href="#what-are-the-expected-probability-states-after-one-or-two-steps">What are the expected probability states after one or two steps?</a></li>
+<li><a href="#what-about-an-abitrary-number-of-time-steps">What about an abitrary number of time steps?</a><ul>
+<li><a href="#session-information">Session information</a></li>
+</ul></li>
+</ul>
+</div>
+
+<p><strong>Last updated:</strong> 2016-01-31</p>
+<p><strong>Code version:</strong> bb814effed5b9b66fd67079b6f56e074d539172b</p>
+<div id="pre-requisites" class="section level1">
+<h1>Pre-requisites</h1>
+<p>An understanding of matrix multiplication and matrix powers.</p>
+</div>
+<div id="overview" class="section level1">
+<h1>Overview</h1>
+<p>Here we provide a quick introduction to discrete Markov Chains.</p>
+</div>
+<div id="definition-of-a-markov-chain" class="section level1">
+<h1>Definition of a Markov Chain</h1>
+<p>A Markov Chain is a discrete stochastic process with the <em>Markov property</em> : <span class="math">\(P(X_t|X_{t-1},\ldots,X_1)= P(X_t|X_{t-1})\)</span>. It is fully determined by a probability transition matrix <span class="math">\(P\)</span> which defines the transition probabilities (<span class="math">\(P_ij=P(X_t=j|X_{t-1}=i)\)</span> and an initial probability distribution specficied by the vector <span class="math">\(x\)</span> where <span class="math">\(x_i=P(X_0=i)\)</span>. The time-dependent random variable <span class="math">\(X_t\)</span> is describing the state of our probabilistic system at time-step <span class="math">\(t\)</span>.</p>
+</div>
+<div id="example-garys-mood" class="section level1">
+<h1>Example: Gary’s mood</h1>
+<p>In Sheldon Ross’s Introduction to Probability Models, he has an example (4.3) of a Markov Chain for modeling Gary’s mood. Gary alternates between 3 state: Cheery (<span class="math">\(X=1\)</span>), So-So (<span class="math">\(X=2\)</span>), or Glum (<span class="math">\(X=3\)</span>). Here we input the <span class="math">\(P\)</span> matrix given by Ross and we input an abitrary initial probability matrix.</p>
+<pre class="r"><code># Define prob transition matrix 
+# (note matrix() takes vectors in column form so there is a transpose here to switch col&#39;s to row&#39;s)
+P=t(matrix(c(c(0.5,0.4,0.1),c(0.3,0.4,0.3),c(0.2,0.3,0.5)),nrow=3))
+# Check sum across = 1
+apply(P,1,sum)  </code></pre>
+<pre><code>[1] 1 1 1</code></pre>
+<pre class="r"><code># Definte initial probability vector
+x0=c(0.1,0.2,0.7)
+# Check sums to 1
+sum(x0)</code></pre>
+<pre><code>[1] 1</code></pre>
+</div>
+<div id="what-are-the-expected-probability-states-after-one-or-two-steps" class="section level1">
+<h1>What are the expected probability states after one or two steps?</h1>
+<p>If initial prob distribution <span class="math">\(x_0\)</span> is <span class="math">\(3 \times 1\)</span> column vector, then <span class="math">\(x_0^T P= x_1^T\)</span>. In R, the %*% operator automatically promotes a vector to the appropriate matrix to make the arguments conformable. In the case of multiplying a length 3 vector by a <span class="math">\(3\time 3\)</span> matrix, it takes the vector to be a row-vector. This means our math can look simply:</p>
+<pre class="r"><code># After one step
+x0%*%P</code></pre>
+<pre><code>     [,1] [,2] [,3]
+[1,] 0.25 0.33 0.42</code></pre>
+<p>And after two time-steps:</p>
+<pre class="r"><code>## The two-step prob trans matrix
+P%*%P</code></pre>
+<pre><code>     [,1] [,2] [,3]
+[1,] 0.39 0.39 0.22
+[2,] 0.33 0.37 0.30
+[3,] 0.29 0.35 0.36</code></pre>
+<pre class="r"><code>## Multiplied by the initial state probability
+x0%*%P%*%P</code></pre>
+<pre><code>      [,1]  [,2]  [,3]
+[1,] 0.308 0.358 0.334</code></pre>
+</div>
+<div id="what-about-an-abitrary-number-of-time-steps" class="section level1">
+<h1>What about an abitrary number of time steps?</h1>
+<p>To generalize to an abitrary number of time steps into the future, we can compute a the matrix power. In R, this can be done easily with the package expm. Let’s load the library and verify the second power is the same as we saw for P%*%P above.</p>
+<pre class="r"><code># Load library 
+library(expm)</code></pre>
+<pre><code>Loading required package: Matrix
+
+Attaching package: &#39;expm&#39;
+
+The following object is masked from &#39;package:Matrix&#39;:
+
+    expm</code></pre>
+<pre class="r"><code># Verify the second power is P%*%P
+P%^%2</code></pre>
+<pre><code>     [,1] [,2] [,3]
+[1,] 0.39 0.39 0.22
+[2,] 0.33 0.37 0.30
+[3,] 0.29 0.35 0.36</code></pre>
+<p>And now let’s push this : Looking at the state of the chain after many steps, say 100. First let’s look at the probability transition matrix…</p>
+<pre class="r"><code>P%^%100</code></pre>
+<pre><code>          [,1]      [,2]      [,3]
+[1,] 0.3387097 0.3709677 0.2903226
+[2,] 0.3387097 0.3709677 0.2903226
+[3,] 0.3387097 0.3709677 0.2903226</code></pre>
+<p>What do you notice about the rows? And let’s see what this does for various starting distrbutions:</p>
+<pre class="r"><code>c(1,0,0) %*%(P%^%100)</code></pre>
+<pre><code>          [,1]      [,2]      [,3]
+[1,] 0.3387097 0.3709677 0.2903226</code></pre>
+<pre class="r"><code>c(0.2,0.5,0.3) %*%(P%^%100)</code></pre>
+<pre><code>          [,1]      [,2]      [,3]
+[1,] 0.3387097 0.3709677 0.2903226</code></pre>
+<p>Note that after a large number of steps the initial state does not matter any more, the probability of the chain being in any state <span class="math">\(j\)</span> is independent of where we started. This is our first view of the <em>equilibrium distribuion</em> of a Markov Chain. These are also known as the <em>limiting probabilities of a Markov chain</em> or <em>stationary distribution</em>.</p>
+<div id="session-information" class="section level2">
+<h2>Session information</h2>
+<pre class="r"><code>sessionInfo()</code></pre>
+<pre><code>R version 3.2.0 (2015-04-16)
+Platform: x86_64-apple-darwin13.4.0 (64-bit)
+Running under: OS X 10.11.2 (unknown)
+
+locale:
+[1] en_US.UTF-8/en_US.UTF-8/en_US.UTF-8/C/en_US.UTF-8/en_US.UTF-8
+
+attached base packages:
+[1] stats     graphics  grDevices utils     datasets  methods   base     
+
+other attached packages:
+[1] expm_0.999-0 Matrix_1.2-1 knitr_1.10.5
+
+loaded via a namespace (and not attached):
+ [1] magrittr_1.5    formatR_1.2     tools_3.2.0     htmltools_0.2.6
+ [5] yaml_2.1.13     stringi_0.4-1   rmarkdown_0.7   grid_3.2.0     
+ [9] stringr_1.0.0   digest_0.6.8    lattice_0.20-31 evaluate_0.7   </code></pre>
+</div>
+</div>
+
+
+<!-- some extra javascript for older browsers -->
+<script type="text/javascript" src="libs/polyfill.js"></script>
+
+<script>
+
+// manage active state of menu based on current page
+$(document).ready(function () {
+
+    // active menu
+    href = window.location.pathname
+    href = href.substr(href.lastIndexOf('/') + 1)
+    $('a[href="' + href + '"]').parent().addClass('active');
+
+    // manage active menu header
+    if (href.startsWith('authoring_'))
+      $('a[href="' + 'authoring' + '"]').parent().addClass('active');
+    else if (href.endsWith('_format.html'))
+      $('a[href="' + 'formats' + '"]').parent().addClass('active');
+    else if (href.startsWith('developer_'))
+      $('a[href="' + 'developer' + '"]').parent().addClass('active');
+
+});
+
+</script>
+
+</div>
+
+<script>
+
+// add bootstrap table styles to pandoc tables
+$(document).ready(function () {
+  $('tr.header').parent('thead').parent('table').addClass('table table-condensed');
+});
+
+</script>
+
+<!-- dynamically load mathjax for compatibility with self-contained -->
+<script>
+  (function () {
+    var script = document.createElement("script");
+    script.type = "text/javascript";
+    script.src  = "https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML";
+    document.getElementsByTagName("head")[0].appendChild(script);
+  })();
+</script>
+
+</body>
+</html>

--- a/analysis/markov_chains_discrete_stationary_dist.Rmd
+++ b/analysis/markov_chains_discrete_stationary_dist.Rmd
@@ -1,0 +1,154 @@
+---
+title: "Computing Stationary Distributions of a Discrete Markov Chain"
+author: "John Novembre"
+date: 2016-01-31
+---
+
+**Last updated:** `r Sys.Date()`
+
+**Code version:** `r system("git log -1 --format='%H'", intern = TRUE)`
+
+```{r chunk-options, include=FALSE}
+source("chunk-options.R")
+```
+
+# Pre-requisites
+
+This vignette builds on the Introduction to Discrete Markov chains vignette.  It assumes an understanding of matrix multiplication, matrix powers, and eigendecomposition.  We also do not explain the notion of an ergodic Markov chain (but we hope to add a vignette on this soon!). 
+
+# Overview
+
+The stationary distribution of a Markov chain is an important feature of the chain.  Here we explore several ways to compute the stationary distribution for a simple example of a Markov chain.  One of the ways is using an eigendecomposition.  The eigendecomposition is also useful because it suggests how we can quickly compute matrix powers like $P^n$ and how we can assess the rate of convergence to a stationary distribution.
+
+# Stationary distribution of a Markov Chain
+
+As part of the definition of a Markov chain, there is some probability distribution on the states at time $0$.  Each time step the distribution on states evolves - some states may become more likely and others less likely and this is dictated by $P$.  The *stationary distribution* of a Markov chain describes the distribution of $X_t$ after a sufficiently long time that the distribution of $X_t$ does not change any longer.  To put this notion in equation form, let $\pi$ be a column vector of probabilities on the states that a Markov chain can visit.  Then, $\pi$ is the stationary distribution if it has the property $$\pi^T= \pi^T P.$$  
+
+Not all Morkov chains have a stationary disribution but for some classes of probability transition matrix (those defining *ergodic* Markov chains), a stationary distribution is guaranteed to exist.  Here we will explore several approaches for calculating the stationary distribuiton of a simple, ergodic Markov chain. 
+
+# Example: Gary's mood
+
+In Sheldon Ross's Introduction to Probability Models, he has an example (4.3) of a Markov Chain for modeling Gary's mood.  Gary alternates between 3 state: Cheery ($X=1$), So-So ($X=2$), or Glum ($X=3$).  Here we input the $P$ matrix given by Ross and we input an abitrary initial probability matrix. 
+
+```{r}
+# Define prob transition matrix 
+# (note matrix() takes vectors in column form so there is a transpose here to switch col's to row's)
+P=t(matrix(c(c(0.5,0.4,0.1),c(0.3,0.4,0.3),c(0.2,0.3,0.5)),nrow=3))
+# Check sum across = 1
+apply(P,1,sum)  
+
+# Definte initial probability vector
+x0=c(0.1,0.2,0.7)
+# Check sums to 1
+sum(x0)
+```
+
+
+## Solving for stationary distributions 
+The stationary distribution has the property $\pi^T= \pi^T P$
+
+### Brute-force solution
+
+A brute-force hack to finding the stationary distribution is simply to take the transition matrix to a high power and then extract out any row. 
+
+```{r}
+pi_bru=(P%^%100)[1,]
+```
+
+We can test if the resulting vector is a stationary distribution by assessing if the resulting vector statisfies $\pi^{T}=pi^{T}P$ (i.e. $pi^{T}-pi^{T}P -  = 0$).
+```{r}
+pi_bru - pi_bru%*%P
+```
+As we can see up to some very small errors, for this example, our numerical solution checks out.
+
+### Solving a system of linear equations solution
+Another approach is to solve the system of linear equations $\pi^{T}=\pi^{T}P$.  Most generic solvers need to have the equations expressed as $Ax=b$.  We can re-arrange to get $(I-P)^T \pi =0_{K\times 1}$ where $K$ is the number of possible states taken by $X_{\cdot}$.  So $A=(I-P)^T$ and $b=0_{K\times 1}$.  One challenge though is that we need the constrained solution which respects that $\pi$ describes a probability disribution (i.e. $\sum \pi_i = 1$).  Luckily this is a linear constraint that is easily represented by adding another equation to the system.  So as a small trick, we need to add a row all 1's to our $A$ and a 1 to $b$.  We will have a non-square matrix $A$ as a result, and we will need to use the =limSolve= library in place of R's generic solve function.
+
+```{R}
+K<-3
+A_basic <- t(diag(rep(1,K))-P)
+b_basic <- rep(0,K)
+# Now add the constraint 
+A_constr <- rbind(A,rep(1,K))
+b_constr <- c(b,1)
+# And since we now have a non-square matrix we need a more generic solver library
+library(limSolve)
+pi_lineq <- Solve(A_constr,b_constr)
+pi_lineq
+sum(pi_lineq)
+pi_lineq%*%P
+```
+And the solution checks out!
+
+### Solving via eigendecomposition
+
+Note that the equation $\pi^T P=\pi^T$ implies that the vector $\pi$ is a left eigenvector of P with eigenvalue equal to 1 (Recall $xA=\lambda x$ where $x$ is a row vector is definition of a left eigenvector, as opposed to the more standard right eigenvector $Ax=\lambda x$). In what follows, we use eigenvector functions in R to extract out the solution. 
+
+```{r}
+library(MASS)
+# Get the eigenvectors of P, note: R returns right eigenvectors
+r=eigen(P)
+rvec=r$vectors
+# left eigenvectors are the inverse of the right eigenvectors
+lvec=ginv(r$vectors)
+# The eigenvalues
+lam<-r$values
+# Two ways of checking the spectral decomposition:
+## Standard definition
+rvec%*%diag(lam)%*%ginv(rvec)
+## With left eigenvectors (trivial chang)
+rvec%*%diag(lam)%*%lvec
+
+lam 
+```
+We see the first eigenvalue is $1$ and so the first left eigenvector, suitably normalized, should contain the stationary distribution:
+```{r}
+pi_eig<-lvec[1,]/sum(lvec[1,])
+pi_eig
+sum(pi_eig)
+pi_eig %*% P
+```
+And we see the procedure checks out.  
+
+As a side-note: We can also obtain the left eigenvectors as the transposes of the right eigenvectors of t(P) 
+```{r}
+r<-eigen(t(P))
+V<-r$vectors
+lam<-r$values
+V%*%diag(lam)%*%ginv(V)
+# Note how we are pulling columns here. 
+pi_eig2 <- V[,1]/sum(V[,1])
+```
+
+
+#### Numerical advantages of using an eigendecomposition for matrix powers
+
+Thanks to the eigenvector decomposition, to obtain the matrix power $P^n$ we just need to take the powers of the eigenvalues.  Compare the following lines of code to $P$,$P^2$, $P^100$ computed above.  And note - this is much faster than naively doing the matrix multipliation over and over to obtain the powers.
+```{r}
+rvec%*%diag(lam)%*%lvec
+
+rvec%*%diag(lam^2)%*%lvec
+
+rvec%*%diag(lam^100)%*%lvec
+
+```
+
+#### A side-note on the eigendecomposition: Rate of approach to equilbirium
+
+The size of the first non-unit eigenvalue ($\lambda_2$) indicates the rate of approach to equilibrium (because it describes how quickly the largest of the vanishing terms (i.e. those with $\lambda_i<1$) will approach zero.  The times-scale of decay is $1/\lambda_2$ time-steps.  So after some small multiple of $1/\lambda_2$ generations, we will expect to be at equilibrium.  
+
+For our example, $1/\lambda_2$ is approximately 3 generations.
+```{r}
+# 1/lam[2] is rather small
+1/lam[2]
+```
+Which implies we will reach equilibrium fairly quickly - much more quickly than the 100 generations we were using for our brute-force hack.   As a test, let's see how $P^9$ looks: 
+P%^%9
+```
+Indeed - Gary's mood will have return to it's stationary distribution relatively quickly after any perturbation! 
+
+## Session information
+
+```{r info}
+sessionInfo()
+```

--- a/analysis/markov_chains_discrete_stationary_dist.Rmd
+++ b/analysis/markov_chains_discrete_stationary_dist.Rmd
@@ -10,6 +10,7 @@ date: 2016-01-31
 
 ```{r chunk-options, include=FALSE}
 source("chunk-options.R")
+library(expm)
 ```
 
 # Pre-requisites
@@ -44,15 +45,16 @@ sum(x0)
 ```
 
 
-## Solving for stationary distributions 
+# Solving for stationary distributions 
 The stationary distribution has the property $\pi^T= \pi^T P$
 
-### Brute-force solution
+## Brute-force solution
 
 A brute-force hack to finding the stationary distribution is simply to take the transition matrix to a high power and then extract out any row. 
 
 ```{r}
-pi_bru=(P%^%100)[1,]
+pi_bru <- (P%^%100)[1,]
+pi_bru
 ```
 
 We can test if the resulting vector is a stationary distribution by assessing if the resulting vector statisfies $\pi^{T}=pi^{T}P$ (i.e. $pi^{T}-pi^{T}P -  = 0$).
@@ -61,7 +63,7 @@ pi_bru - pi_bru%*%P
 ```
 As we can see up to some very small errors, for this example, our numerical solution checks out.
 
-### Solving a system of linear equations solution
+## Solving a system of linear equations solution
 Another approach is to solve the system of linear equations $\pi^{T}=\pi^{T}P$.  Most generic solvers need to have the equations expressed as $Ax=b$.  We can re-arrange to get $(I-P)^T \pi =0_{K\times 1}$ where $K$ is the number of possible states taken by $X_{\cdot}$.  So $A=(I-P)^T$ and $b=0_{K\times 1}$.  One challenge though is that we need the constrained solution which respects that $\pi$ describes a probability disribution (i.e. $\sum \pi_i = 1$).  Luckily this is a linear constraint that is easily represented by adding another equation to the system.  So as a small trick, we need to add a row all 1's to our $A$ and a 1 to $b$.  We will have a non-square matrix $A$ as a result, and we will need to use the =limSolve= library in place of R's generic solve function.
 
 ```{R}
@@ -69,8 +71,8 @@ K<-3
 A_basic <- t(diag(rep(1,K))-P)
 b_basic <- rep(0,K)
 # Now add the constraint 
-A_constr <- rbind(A,rep(1,K))
-b_constr <- c(b,1)
+A_constr <- rbind(A_basic,rep(1,K))
+b_constr <- c(b_basic,1)
 # And since we now have a non-square matrix we need a more generic solver library
 library(limSolve)
 pi_lineq <- Solve(A_constr,b_constr)
@@ -80,7 +82,7 @@ pi_lineq%*%P
 ```
 And the solution checks out!
 
-### Solving via eigendecomposition
+## Solving via eigendecomposition
 
 Note that the equation $\pi^T P=\pi^T$ implies that the vector $\pi$ is a left eigenvector of P with eigenvalue equal to 1 (Recall $xA=\lambda x$ where $x$ is a row vector is definition of a left eigenvector, as opposed to the more standard right eigenvector $Ax=\lambda x$). In what follows, we use eigenvector functions in R to extract out the solution. 
 
@@ -120,8 +122,24 @@ V%*%diag(lam)%*%ginv(V)
 pi_eig2 <- V[,1]/sum(V[,1])
 ```
 
+## Rate of approach to the stationary distribution
 
-#### Numerical advantages of using an eigendecomposition for matrix powers
+The size of the first non-unit eigenvalue ($\lambda_2$) indicates the rate of approach to equilibrium because it describes how quickly the largest of the vanishing terms (i.e. those with $\lambda_i<1$) will approach zero.  
+
+This is easiest seen by recalling the eigendecomposition of $P^n$ can be written as $$P^n\sum_i  \lambda_i^n r_i l_i^T$$, where $r_i$, $l_i$, and $\lambda_i$ are right eigenvectors, left eigenvectors, and eigenvalues of the matrix $P$, respectively.  So, when $\lambda_2^n$ approaches 0, the only terms left in the eigendecomposition will be the terms corresponding to the first eigenvalue - i.e. the stationary distribution!  As a rough rule of thumb for approximation, taking a number $x$ less than 1 to the $n$'th power will approach 0 if $n$ is larger than some small multiple of $1/x$ time-steps (e.g if n > 4/x). 
+
+
+For our example, $1/\lambda_2$ is approximately 3 generations.
+```{r}
+1/lam[2]
+```
+Which implies we will reach equilibrium fairly quickly - much more quickly than the 100 generations we were using for our brute-force soluton to the stationary distribution. As a test, let's see how $P^12$ (i.e approx $4/\lambda_2$) looks: 
+```{r}
+P%^%12
+```
+Indeed - Gary's mood will return to its stationary distribution relatively quickly after any perturbation! 
+
+## A side-note: Computational advantage of using an eigendecomposition for matrix powers
 
 Thanks to the eigenvector decomposition, to obtain the matrix power $P^n$ we just need to take the powers of the eigenvalues.  Compare the following lines of code to $P$,$P^2$, $P^100$ computed above.  And note - this is much faster than naively doing the matrix multipliation over and over to obtain the powers.
 ```{r}
@@ -133,19 +151,6 @@ rvec%*%diag(lam^100)%*%lvec
 
 ```
 
-#### A side-note on the eigendecomposition: Rate of approach to equilbirium
-
-The size of the first non-unit eigenvalue ($\lambda_2$) indicates the rate of approach to equilibrium (because it describes how quickly the largest of the vanishing terms (i.e. those with $\lambda_i<1$) will approach zero.  The times-scale of decay is $1/\lambda_2$ time-steps.  So after some small multiple of $1/\lambda_2$ generations, we will expect to be at equilibrium.  
-
-For our example, $1/\lambda_2$ is approximately 3 generations.
-```{r}
-# 1/lam[2] is rather small
-1/lam[2]
-```
-Which implies we will reach equilibrium fairly quickly - much more quickly than the 100 generations we were using for our brute-force hack.   As a test, let's see how $P^9$ looks: 
-P%^%9
-```
-Indeed - Gary's mood will have return to it's stationary distribution relatively quickly after any perturbation! 
 
 ## Session information
 

--- a/analysis/markov_chains_discrete_stationary_dist.html
+++ b/analysis/markov_chains_discrete_stationary_dist.html
@@ -1,0 +1,365 @@
+<!DOCTYPE html>
+
+<html xmlns="http://www.w3.org/1999/xhtml">
+
+<head>
+
+<meta charset="utf-8">
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+<meta name="generator" content="pandoc" />
+
+<meta name="author" content="John Novembre" />
+
+<meta name="date" content="2016-01-31" />
+
+<title>Computing Stationary Distributions of a Discrete Markov Chain</title>
+
+<script src="libs/jquery-1.11.0/jquery.min.js"></script>
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<link href="libs/bootstrap-3.3.1/css/united.min.css" rel="stylesheet" />
+<script src="libs/bootstrap-3.3.1/js/bootstrap.min.js"></script>
+<script src="libs/bootstrap-3.3.1/shim/html5shiv.min.js"></script>
+<script src="libs/bootstrap-3.3.1/shim/respond.min.js"></script>
+
+<style type="text/css">
+
+/* padding for bootstrap navbar */
+body {
+  padding-top: 50px;
+  padding-bottom: 40px;
+}
+
+
+/* offset scroll position for anchor links (for fixed navbar)  */
+.section h2 {
+  padding-top: 55px;
+  margin-top: -55px;
+}
+.section h3 {
+  padding-top: 55px;
+  margin-top: -55px;
+}
+
+
+
+/* don't use link color in navbar */
+.dropdown-menu>li>a {
+  color: black;
+}
+
+/* some padding for disqus */
+#disqus_thread {
+  margin-top: 45px;
+}
+
+</style>
+
+<link rel="stylesheet" href="libs/font-awesome-4.1.0/css/font-awesome.min.css"/>
+
+<style type="text/css">code{white-space: pre;}</style>
+<link rel="stylesheet"
+      href="libs/highlight/textmate.css"
+      type="text/css" />
+<script src="libs/highlight/highlight.js"></script>
+<style type="text/css">
+  pre:not([class]) {
+    background-color: white;
+  }
+</style>
+<script type="text/javascript">
+if (window.hljs && document.readyState && document.readyState === "complete") {
+   window.setTimeout(function() {
+      hljs.initHighlighting();
+   }, 0);
+}
+</script>
+
+
+
+</head>
+
+<body>
+
+<style type = "text/css">
+.main-container {
+  max-width: 940px;
+  margin-left: auto;
+  margin-right: auto;
+}
+code {
+  color: inherit;
+  background-color: rgba(0, 0, 0, 0.04);
+}
+img { 
+  max-width:100%; 
+  height: auto; 
+}
+</style>
+<div class="container-fluid main-container">
+
+
+<div class="navbar navbar-default navbar-fixed-top" role="navigation">
+  <div class="container">
+    <div class="navbar-header">
+      <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#navbar">
+        <span class="icon-bar"></span>
+        <span class="icon-bar"></span>
+        <span class="icon-bar"></span>
+      </button>
+      <a class="navbar-brand" href="index.html">fiveMinuteStats</a>
+    </div>
+    <div id="navbar" class="navbar-collapse collapse">
+      <ul class="nav navbar-nav">
+        <li><a href="index.html">Home</a></li>
+        <li><a href="about.html">About</a></li>
+        <li><a href="license.html">License</a></li>
+        <li><a href="https://github.com/stephens999/fiveMinuteStats">GitHub</a></li>
+    </div><!--/.nav-collapse -->
+  </div><!--/.container -->
+</div><!--/.navbar -->
+
+<div id="header">
+<h1 class="title">Computing Stationary Distributions of a Discrete Markov Chain</h1>
+<h4 class="author"><em>John Novembre</em></h4>
+<h4 class="date"><em>2016-01-31</em></h4>
+</div>
+
+<div id="TOC">
+<ul>
+<li><a href="#pre-requisites">Pre-requisites</a></li>
+<li><a href="#overview">Overview</a></li>
+<li><a href="#stationary-distribution-of-a-markov-chain">Stationary distribution of a Markov Chain</a></li>
+<li><a href="#example-garys-mood">Example: Gary’s mood</a></li>
+<li><a href="#solving-for-stationary-distributions">Solving for stationary distributions</a><ul>
+<li><a href="#brute-force-solution">Brute-force solution</a></li>
+<li><a href="#solving-a-system-of-linear-equations-solution">Solving a system of linear equations solution</a></li>
+<li><a href="#solving-via-eigendecomposition">Solving via eigendecomposition</a></li>
+<li><a href="#rate-of-approach-to-the-stationary-distribution">Rate of approach to the stationary distribution</a></li>
+<li><a href="#a-side-note-computational-advantage-of-using-an-eigendecomposition-for-matrix-powers">A side-note: Computational advantage of using an eigendecomposition for matrix powers</a></li>
+<li><a href="#session-information">Session information</a></li>
+</ul></li>
+</ul>
+</div>
+
+<p><strong>Last updated:</strong> 2016-01-31</p>
+<p><strong>Code version:</strong> c8c677bb060d7b9183bbe7a9080b9bbf72d23df8</p>
+<div id="pre-requisites" class="section level1">
+<h1>Pre-requisites</h1>
+<p>This vignette builds on the Introduction to Discrete Markov chains vignette. It assumes an understanding of matrix multiplication, matrix powers, and eigendecomposition. We also do not explain the notion of an ergodic Markov chain (but we hope to add a vignette on this soon!).</p>
+</div>
+<div id="overview" class="section level1">
+<h1>Overview</h1>
+<p>The stationary distribution of a Markov chain is an important feature of the chain. One of the ways is using an eigendecomposition. The eigendecomposition is also useful because it suggests how we can quickly compute matrix powers like <span class="math">\(P^n\)</span> and how we can assess the rate of convergence to a stationary distribution.</p>
+</div>
+<div id="stationary-distribution-of-a-markov-chain" class="section level1">
+<h1>Stationary distribution of a Markov Chain</h1>
+<p>As part of the definition of a Markov chain, there is some probability distribution on the states at time <span class="math">\(0\)</span>. Each time step the distribution on states evolves - some states may become more likely and others less likely and this is dictated by <span class="math">\(P\)</span>. The <em>stationary distribution</em> of a Markov chain describes the distribution of <span class="math">\(X_t\)</span> after a sufficiently long time that the distribution of <span class="math">\(X_t\)</span> does not change any longer. To put this notion in equation form, let <span class="math">\(\pi\)</span> be a column vector of probabilities on the states that a Markov chain can visit. Then, <span class="math">\(\pi\)</span> is the stationary distribution if it has the property <span class="math">\[\pi^T= \pi^T P.\]</span></p>
+<p>Not all Morkov chains have a stationary disribution but for some classes of probability transition matrix (those defining <em>ergodic</em> Markov chains), a stationary distribution is guaranteed to exist.</p>
+</div>
+<div id="example-garys-mood" class="section level1">
+<h1>Example: Gary’s mood</h1>
+<p>In Sheldon Ross’s Introduction to Probability Models, he has an example (4.3) of a Markov Chain for modeling Gary’s mood. Gary alternates between 3 state: Cheery (<span class="math">\(X=1\)</span>), So-So (<span class="math">\(X=2\)</span>), or Glum (<span class="math">\(X=3\)</span>). Here we input the <span class="math">\(P\)</span> matrix given by Ross and we input an abitrary initial probability matrix.</p>
+<pre class="r"><code># Define prob transition matrix 
+# (note matrix() takes vectors in column form so there is a transpose here to switch col&#39;s to row&#39;s)
+P=t(matrix(c(c(0.5,0.4,0.1),c(0.3,0.4,0.3),c(0.2,0.3,0.5)),nrow=3))
+# Check sum across = 1
+apply(P,1,sum)  </code></pre>
+<pre><code>[1] 1 1 1</code></pre>
+<pre class="r"><code># Definte initial probability vector
+x0=c(0.1,0.2,0.7)
+# Check sums to 1
+sum(x0)</code></pre>
+<pre><code>[1] 1</code></pre>
+</div>
+<div id="solving-for-stationary-distributions" class="section level1">
+<h1>Solving for stationary distributions</h1>
+<p>The stationary distribution has the property <span class="math">\(\pi^T= \pi^T P\)</span></p>
+<div id="brute-force-solution" class="section level2">
+<h2>Brute-force solution</h2>
+<p>A brute-force hack to finding the stationary distribution is simply to take the transition matrix to a high power and then extract out any row.</p>
+<pre class="r"><code>pi_bru &lt;- (P%^%100)[1,]
+pi_bru</code></pre>
+<pre><code>[1] 0.3387097 0.3709677 0.2903226</code></pre>
+<p>We can test if the resulting vector is a stationary distribution by assessing if the resulting vector statisfies <span class="math">\(\pi^{T}=pi^{T}P\)</span> (i.e. <span class="math">\(pi^{T}-pi^{T}P - = 0\)</span>).</p>
+<pre class="r"><code>pi_bru - pi_bru%*%P</code></pre>
+<pre><code>             [,1]          [,2] [,3]
+[1,] 5.551115e-17 -5.551115e-17    0</code></pre>
+<p>As we can see up to some very small errors, for this example, our numerical solution checks out.</p>
+</div>
+<div id="solving-a-system-of-linear-equations-solution" class="section level2">
+<h2>Solving a system of linear equations solution</h2>
+<p>Another approach is to solve the system of linear equations <span class="math">\(\pi^{T}=\pi^{T}P\)</span>. Most generic solvers need to have the equations expressed as <span class="math">\(Ax=b\)</span>. We can re-arrange to get <span class="math">\((I-P)^T \pi =0_{K\times 1}\)</span> where <span class="math">\(K\)</span> is the number of possible states taken by <span class="math">\(X_{\cdot}\)</span>. So <span class="math">\(A=(I-P)^T\)</span> and <span class="math">\(b=0_{K\times 1}\)</span>. One challenge though is that we need the constrained solution which respects that <span class="math">\(\pi\)</span> describes a probability disribution (i.e. <span class="math">\(\sum \pi_i = 1\)</span>). Luckily this is a linear constraint that is easily represented by adding another equation to the system. So as a small trick, we need to add a row all 1’s to our <span class="math">\(A\)</span> and a 1 to <span class="math">\(b\)</span>. We will have a non-square matrix <span class="math">\(A\)</span> as a result, and we will need to use the =limSolve= library in place of R’s generic solve function.</p>
+<pre class="r"><code>K&lt;-3
+A_basic &lt;- t(diag(rep(1,K))-P)
+b_basic &lt;- rep(0,K)
+# Now add the constraint 
+A_constr &lt;- rbind(A_basic,rep(1,K))
+b_constr &lt;- c(b_basic,1)
+# And since we now have a non-square matrix we need a more generic solver library
+library(limSolve)
+pi_lineq &lt;- Solve(A_constr,b_constr)
+pi_lineq</code></pre>
+<pre><code>[1] 0.3387097 0.3709677 0.2903226</code></pre>
+<pre class="r"><code>sum(pi_lineq)</code></pre>
+<pre><code>[1] 1</code></pre>
+<pre class="r"><code>pi_lineq%*%P</code></pre>
+<pre><code>          [,1]      [,2]      [,3]
+[1,] 0.3387097 0.3709677 0.2903226</code></pre>
+<p>And the solution checks out!</p>
+</div>
+<div id="solving-via-eigendecomposition" class="section level2">
+<h2>Solving via eigendecomposition</h2>
+<p>Note that the equation <span class="math">\(\pi^T P=\pi^T\)</span> implies that the vector <span class="math">\(\pi\)</span> is a left eigenvector of P with eigenvalue equal to 1 (Recall <span class="math">\(xA=\lambda x\)</span> where <span class="math">\(x\)</span> is a row vector is definition of a left eigenvector, as opposed to the more standard right eigenvector <span class="math">\(Ax=\lambda x\)</span>). In what follows, we use eigenvector functions in R to extract out the solution.</p>
+<pre class="r"><code>library(MASS)
+# Get the eigenvectors of P, note: R returns right eigenvectors
+r=eigen(P)
+rvec=r$vectors
+# left eigenvectors are the inverse of the right eigenvectors
+lvec=ginv(r$vectors)
+# The eigenvalues
+lam&lt;-r$values
+# Two ways of checking the spectral decomposition:
+## Standard definition
+rvec%*%diag(lam)%*%ginv(rvec)</code></pre>
+<pre><code>     [,1] [,2] [,3]
+[1,]  0.5  0.4  0.1
+[2,]  0.3  0.4  0.3
+[3,]  0.2  0.3  0.5</code></pre>
+<pre class="r"><code>## With left eigenvectors (trivial chang)
+rvec%*%diag(lam)%*%lvec</code></pre>
+<pre><code>     [,1] [,2] [,3]
+[1,]  0.5  0.4  0.1
+[2,]  0.3  0.4  0.3
+[3,]  0.2  0.3  0.5</code></pre>
+<pre class="r"><code>lam </code></pre>
+<pre><code>[1] 1.00000000 0.34142136 0.05857864</code></pre>
+<p>We see the first eigenvalue is <span class="math">\(1\)</span> and so the first left eigenvector, suitably normalized, should contain the stationary distribution:</p>
+<pre class="r"><code>pi_eig&lt;-lvec[1,]/sum(lvec[1,])
+pi_eig</code></pre>
+<pre><code>[1] 0.3387097 0.3709677 0.2903226</code></pre>
+<pre class="r"><code>sum(pi_eig)</code></pre>
+<pre><code>[1] 1</code></pre>
+<pre class="r"><code>pi_eig %*% P</code></pre>
+<pre><code>          [,1]      [,2]      [,3]
+[1,] 0.3387097 0.3709677 0.2903226</code></pre>
+<p>And we see the procedure checks out.</p>
+<p>As a side-note: We can also obtain the left eigenvectors as the transposes of the right eigenvectors of t(P)</p>
+<pre class="r"><code>r&lt;-eigen(t(P))
+V&lt;-r$vectors
+lam&lt;-r$values
+V%*%diag(lam)%*%ginv(V)</code></pre>
+<pre><code>     [,1] [,2] [,3]
+[1,]  0.5  0.3  0.2
+[2,]  0.4  0.4  0.3
+[3,]  0.1  0.3  0.5</code></pre>
+<pre class="r"><code># Note how we are pulling columns here. 
+pi_eig2 &lt;- V[,1]/sum(V[,1])</code></pre>
+</div>
+<div id="rate-of-approach-to-the-stationary-distribution" class="section level2">
+<h2>Rate of approach to the stationary distribution</h2>
+<p>The size of the first non-unit eigenvalue (<span class="math">\(\lambda_2\)</span>) indicates the rate of approach to equilibrium because it describes how quickly the largest of the vanishing terms (i.e. those with <span class="math">\(\lambda_i&lt;1\)</span>) will approach zero.</p>
+<p>This is easiest seen by recalling the eigendecomposition of <span class="math">\(P^n\)</span> can be written as <span class="math">\[P^n\sum_i  \lambda_i^n r_i l_i^T\]</span>, where <span class="math">\(r_i\)</span>, <span class="math">\(l_i\)</span>, and <span class="math">\(\lambda_i\)</span> are right eigenvectors, left eigenvectors, and eigenvalues of the matrix <span class="math">\(P\)</span>, respectively. So, when <span class="math">\(\lambda_2^n\)</span> approaches 0, the only terms left in the eigendecomposition will be the terms corresponding to the first eigenvalue - i.e. the stationary distribution! As a rough rule of thumb for approximation, taking a number <span class="math">\(x\)</span> less than 1 to the <span class="math">\(n\)</span>’th power will approach 0 if <span class="math">\(n\)</span> is larger than some small multiple of <span class="math">\(1/x\)</span> time-steps (e.g if n &gt; 4/x).</p>
+<p>For our example, <span class="math">\(1/\lambda_2\)</span> is approximately 3 generations.</p>
+<pre class="r"><code>1/lam[2]</code></pre>
+<pre><code>[1] 2.928932</code></pre>
+<p>Which implies we will reach equilibrium fairly quickly - much more quickly than the 100 generations we were using for our brute-force soluton to the stationary distribution. As a test, let’s see how <span class="math">\(P^12\)</span> (i.e approx <span class="math">\(4/\lambda_2\)</span>) looks:</p>
+<pre class="r"><code>P%^%12</code></pre>
+<pre><code>          [,1]      [,2]      [,3]
+[1,] 0.3387108 0.3709682 0.2903210
+[2,] 0.3387095 0.3709677 0.2903228
+[3,] 0.3387086 0.3709673 0.2903241</code></pre>
+<p>Indeed - Gary’s mood will return to its stationary distribution relatively quickly after any perturbation!</p>
+</div>
+<div id="a-side-note-computational-advantage-of-using-an-eigendecomposition-for-matrix-powers" class="section level2">
+<h2>A side-note: Computational advantage of using an eigendecomposition for matrix powers</h2>
+<p>Thanks to the eigenvector decomposition, to obtain the matrix power <span class="math">\(P^n\)</span> we just need to take the powers of the eigenvalues. Compare the following lines of code to <span class="math">\(P\)</span>,<span class="math">\(P^2\)</span>, <span class="math">\(P^100\)</span> computed above. And note - this is much faster than naively doing the matrix multipliation over and over to obtain the powers.</p>
+<pre class="r"><code>rvec%*%diag(lam)%*%lvec</code></pre>
+<pre><code>     [,1] [,2] [,3]
+[1,]  0.5  0.4  0.1
+[2,]  0.3  0.4  0.3
+[3,]  0.2  0.3  0.5</code></pre>
+<pre class="r"><code>rvec%*%diag(lam^2)%*%lvec</code></pre>
+<pre><code>     [,1] [,2] [,3]
+[1,] 0.39 0.39 0.22
+[2,] 0.33 0.37 0.30
+[3,] 0.29 0.35 0.36</code></pre>
+<pre class="r"><code>rvec%*%diag(lam^100)%*%lvec</code></pre>
+<pre><code>          [,1]      [,2]      [,3]
+[1,] 0.3387097 0.3709677 0.2903226
+[2,] 0.3387097 0.3709677 0.2903226
+[3,] 0.3387097 0.3709677 0.2903226</code></pre>
+</div>
+<div id="session-information" class="section level2">
+<h2>Session information</h2>
+<pre class="r"><code>sessionInfo()</code></pre>
+<pre><code>R version 3.2.0 (2015-04-16)
+Platform: x86_64-apple-darwin13.4.0 (64-bit)
+Running under: OS X 10.11.2 (unknown)
+
+locale:
+[1] en_US.UTF-8/en_US.UTF-8/en_US.UTF-8/C/en_US.UTF-8/en_US.UTF-8
+
+attached base packages:
+[1] stats     graphics  grDevices utils     datasets  methods   base     
+
+other attached packages:
+[1] MASS_7.3-40      limSolve_1.5.5.1 expm_0.999-0     Matrix_1.2-1    
+[5] knitr_1.10.5    
+
+loaded via a namespace (and not attached):
+ [1] quadprog_1.5-5  lattice_0.20-31 digest_0.6.8    grid_3.2.0     
+ [5] formatR_1.2     magrittr_1.5    evaluate_0.7    stringi_0.4-1  
+ [9] rmarkdown_0.7   tools_3.2.0     stringr_1.0.0   yaml_2.1.13    
+[13] htmltools_0.2.6 lpSolve_5.6.13 </code></pre>
+</div>
+</div>
+
+
+<!-- some extra javascript for older browsers -->
+<script type="text/javascript" src="libs/polyfill.js"></script>
+
+<script>
+
+// manage active state of menu based on current page
+$(document).ready(function () {
+
+    // active menu
+    href = window.location.pathname
+    href = href.substr(href.lastIndexOf('/') + 1)
+    $('a[href="' + href + '"]').parent().addClass('active');
+
+    // manage active menu header
+    if (href.startsWith('authoring_'))
+      $('a[href="' + 'authoring' + '"]').parent().addClass('active');
+    else if (href.endsWith('_format.html'))
+      $('a[href="' + 'formats' + '"]').parent().addClass('active');
+    else if (href.startsWith('developer_'))
+      $('a[href="' + 'developer' + '"]').parent().addClass('active');
+
+});
+
+</script>
+
+</div>
+
+<script>
+
+// add bootstrap table styles to pandoc tables
+$(document).ready(function () {
+  $('tr.header').parent('thead').parent('table').addClass('table table-condensed');
+});
+
+</script>
+
+<!-- dynamically load mathjax for compatibility with self-contained -->
+<script>
+  (function () {
+    var script = document.createElement("script");
+    script.type = "text/javascript";
+    script.src  = "https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML";
+    document.getElementsByTagName("head")[0].appendChild(script);
+  })();
+</script>
+
+</body>
+</html>

--- a/analysis/markov_chains_time_reversibility.Rmd
+++ b/analysis/markov_chains_time_reversibility.Rmd
@@ -1,0 +1,70 @@
+---
+title: "Time reversibility of a Markov Chain"
+author: "John Novembre"
+date: 2016-01-31
+---
+
+**Last updated:** `r Sys.Date()`
+
+**Code version:** `r system("git log -1 --format='%H'", intern = TRUE)`
+
+```{r chunk-options, include=FALSE}
+source("chunk-options.R")
+```
+
+# Pre-requisites
+
+TBD
+
+# Overview
+
+TBD
+
+# Time reversibility of a Markov Chain
+
+TBD
+
+# Example: Gary's mood
+
+In Sheldon Ross's Introduction to Probability Models, he has an example (4.3) of a Markov Chain for modeling Gary's mood.  Gary alternates between 3 state: Cheery ($X=1$), So-So ($X=2$), or Glum ($X=3$).  Here we input the $P$ matrix given by Ross and we input an abitrary initial probability matrix. 
+
+```{r}
+# Define prob transition matrix 
+# (note matrix() takes vectors in column form so there is a transpose here to switch col's to row's)
+P=t(matrix(c(c(0.5,0.4,0.1),c(0.3,0.4,0.3),c(0.2,0.3,0.5)),nrow=3))
+# Check sum across = 1
+apply(P,1,sum)  
+
+# Definte initial probability vector
+x0=c(0.1,0.2,0.7)
+# Check sums to 1
+sum(x0)
+```
+
+
+
+#### Time-reversibility
+
+The reverse chain transition prob's are: $$\frac{\pi_j P_{ji}}{\pi_i}$$
+```{r}
+diag(1/pivec)%*%(t(P)%*%diag(pivec))
+```
+So for our example we see it's not time reversible...
+
+Let's make a time-reversible example...
+```{r}
+P=t(matrix(c(c(0.5,0.25,0.25),c(0.25,0.45,0.3),c(0.25,0.3,0.45)),nrow=3))
+# Check sum across = 1
+apply(P,1,sum)  
+
+# And the stationary distribution would be
+pi0=(P%^%100)[1,]
+# Now we check time reversibility
+diag(1/pi0)%*%t(P)%*%diag(pi0)
+```
+
+## Session information
+
+```{r info}
+sessionInfo()
+```


### PR DESCRIPTION
This adds vignette material for introducing Markov Chains and showing how the eigendecomposition can be used to solve the stationary distribution, assess the rate of approach to the stationary distribution and compute matrix powers. 
