### PR TITLE
Update contributing instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,10 +33,10 @@ Each vignette is an R Markdown file, saved in the 'analysis' subdirectory. To ad
 
 ```r
 library("workflowr")
-wflow_open("newfile.Rmd")
+wflow_open("analysis/newfile.Rmd")
 ```
 
 See the [workflowr online documentation][docs] to learn more.
 
-[workflowr]: https://github.com/jdblischak/workflowr
-[docs]: https://jdblischak.github.io/workflowr
+[workflowr]: https://github.com/workflowr/workflowr
+[docs]: https://workflowr.github.io/workflowr


### PR DESCRIPTION
This PR includes minor updates to the contributing instructions:

* Update URL to workflowr GitHub org. The repo URL redirects correctly, but not the documentation URL
* Include the path to `analysis/` in the call to `wflow_open()`. In previous versions of workflowr, `wflow_open()` automatically determined where to save the new Rmd file. But we decided this convenience wasn't worth the potential confusion to end users