### PR TITLE
Update broken and moved URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Modularizing facilitates sharing the load.
 In principle we can have multiple vignettes for the same concept and users can choose which one they like.
 
 The idea of breaking learning down into small chunks is kind of obvious, but I was personally inspired by
-watching videos with my kids: http://www.artofproblemsolving.com/videos/prealgebra
+watching videos with my kids: <https://artofproblemsolving.com/videos/prealgebra>
 Maybe we can make learning statistics this easy and this much fun?
 However, I decided against video because a) I'm not as funny as this guy, and b) it is harder to collaborate and
 update videos.
@@ -39,4 +39,4 @@ wflow_open("analysis/newfile.Rmd")
 See the [workflowr online documentation][docs] to learn more.
 
 [workflowr]: https://github.com/workflowr/workflowr
-[docs]: https://workflowr.github.io/workflowr
+[docs]: https://workflowr.github.io/workflowr/

--- a/analysis/about.Rmd
+++ b/analysis/about.Rmd
@@ -4,4 +4,4 @@ title: "About"
 
 [Matthew Stephens][github-io] is a Professor in Statistics and Human Genetics at the University of Chicago.
 
-[github-io]: http://stephens999.github.io/
+[github-io]: https://stephens999.github.io/blog/

--- a/analysis/approx_wright_fisher_model.Rmd
+++ b/analysis/approx_wright_fisher_model.Rmd
@@ -79,7 +79,7 @@ The beta approximation has many useful properties but it is not defined at 0.0 a
 
 ### Beta with Spikes
 
-A recent publication described a modification of the beta approximation that helps to solve the problem described above. The essential idea of the publication is to use the same beta distribution as above to approximate the distribution of allele frequencies under the Wright-Fisher as well as additionally adding spikes to the boundries of the distribution, allowing for probability mass at both 0.0 and 1.0. This addition of spikes drastically increases the accuracy of the approximation for a pure drift model but also holds promising applications for modeling allele frequency trajectories with selection. See the paper [here](http://www.genetics.org/content/early/2015/08/26/genetics.115.179606).
+A recent publication described a modification of the beta approximation that helps to solve the problem described above. The essential idea of the publication is to use the same beta distribution as above to approximate the distribution of allele frequencies under the Wright-Fisher as well as additionally adding spikes to the boundries of the distribution, allowing for probability mass at both 0.0 and 1.0. This addition of spikes drastically increases the accuracy of the approximation for a pure drift model but also holds promising applications for modeling allele frequency trajectories with selection. See the paper [here](https://doi.org/10.1534/genetics.115.179606).
 
 # Examples
 

--- a/analysis/likelihood_ratio_simple_models.Rmd
+++ b/analysis/likelihood_ratio_simple_models.Rmd
@@ -137,7 +137,7 @@ so you have computed 2000 LRs. Now consider using the LR to classify each tusk a
 
   b) Repeat the above simulation study using 100 tusks from $M_S$ and 1900 tusks from $M_F$. What value of $c$ minimizes the misclassification rate? Comment. 
 
-  Note: it is good practice when writing computing code for a simulation study like this to separate the code into small functions each of which accomplishes a clearly-defined task. So, for example, you should write a function to simulate data, and another to compute the LR (possibly using the function L defined above!), and another to compute the misclassification rate, etc. It is also good practice to comment your functions: eg say what the input parameters are and what the output is. I strongly suggest using [roxygen2](https://cran.r-project.org/web/packages/roxygen2/index.html) format. See [Karl Broman's tutorial](http://kbroman.org/pkg_primer/pages/docs.html) for example.
+  Note: it is good practice when writing computing code for a simulation study like this to separate the code into small functions each of which accomplishes a clearly-defined task. So, for example, you should write a function to simulate data, and another to compute the LR (possibly using the function L defined above!), and another to compute the misclassification rate, etc. It is also good practice to comment your functions: eg say what the input parameters are and what the output is. I strongly suggest using [roxygen2](https://cran.r-project.org/package=roxygen2) format. See [Karl Broman's tutorial](https://kbroman.org/pkg_primer/pages/docs.html) for example.
 
 
 *DO NOT REPEAT THE SIMULATION STUDY BY COPYING AND PASTING CODE AND MODIFYING A FEW NUMBERS! GET INTO THE HABIT OF DOING IT PROPERLY*

--- a/analysis/markov_chains_discrete_intro.Rmd
+++ b/analysis/markov_chains_discrete_intro.Rmd
@@ -52,7 +52,7 @@ x0%*%P%*%P
 ```
 
 # What about an abitrary number of time steps? 
-To generalize to an arbitrary number of time steps into the future, we can compute a the matrix power.  In R, this can be done easily with the package [expm](https://cran.r-project.org/web/packages/expm/index.html).  Let's load the library and verify the second power is the same as we saw for P%*%P above.
+To generalize to an arbitrary number of time steps into the future, we can compute a the matrix power.  In R, this can be done easily with the package [expm](https://cran.r-project.org/package=expm).  Let's load the library and verify the second power is the same as we saw for P%*%P above.
 ```{r}
 # Load library 
 library(expm)

--- a/analysis/shiny_binomial_example.Rmd
+++ b/analysis/shiny_binomial_example.Rmd
@@ -16,7 +16,7 @@ opts_chunk$set(eval = FALSE)
 
 This R Markdown document is made interactive using Shiny. Unlike the more traditional workflow of creating static reports, you can now create documents that allow your readers to change the assumptions underlying your analysis and see the results immediately. 
 
-To learn more, see [Interactive Documents](http://rmarkdown.rstudio.com/authoring_shiny.html).
+To learn more, see [Shiny Documents](https://bookdown.org/yihui/rmarkdown/shiny-documents.html).
 
 ## Inputs and Outputs
 

--- a/analysis/shiny_normal_example.Rmd
+++ b/analysis/shiny_normal_example.Rmd
@@ -46,7 +46,7 @@ when the prior and the (scaled) data likelihood changes:
 
 <div style="text-align: center;"><iframe src="https://nanx.shinyapps.io/conjugate-normal-umkv/" frameborder="0" width="960" height="400"></iframe></div>
 
-The source code of the app can be found [here](https://github.com/road2stat/conjugate-normal-umkv).
+The source code of the app can be found [here](https://github.com/nanxstats/conjugate-normal-umkv).
 
 
 


### PR DESCRIPTION
This PR fixes all broken and moved URLs in `README.md` and `analysis/`.

The links are identified by [using urlchecker](https://nanx.me/blog/post/rmarkdown-quarto-link-checker/) and thus follows the standard that CRAN uses.

Now running `check_url()` shows:

```
fetching [ 26 / 26 ]
✔ All URLs are correct!
```